### PR TITLE
Restrict package to only be installed on windows oses

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "bin": { "NODE_ENV": "index.js" },
   "files": ["index.js"],
+  "os": ["win32"],
   "author": "laggingreflex@gmail.com",
   "repository": "laggingreflex/win-node-env",
   "license": "ISC"


### PR DESCRIPTION
If you set `os` in `package.json`, `npm` and `yarn` won't even try to install this module on non-windows systems. This enables other packages to optionally depend on this if they use `NODE_ENV=...` and `yarn` or `npm` will take care of the rest automagically on all future systems as well!