### PR TITLE
fix(command-parser): split once for env var values using '='

### DIFF
--- a/command-parser.js
+++ b/command-parser.js
@@ -23,8 +23,10 @@ module.exports = args => {
       envDone = true;
       cmd.push(arg);
     } else {
-      let [envVar, value] = arg.split('=');
-      if (!envVar || !value) {
+      const firstSplit = arg.indexOf('=');
+      const envVar = arg.substr(0, firstSplit);
+      let value = arg.substr(firstSplit + 1);
+      if (!envVar || !value || firstSplit === -1) {
         exit(`Invalid env var:`, arg);
         return;
       } else {

--- a/test.js
+++ b/test.js
@@ -17,6 +17,8 @@ describe('command-parser', () => {
   e(`a='1 2' command`, { env: { a: '1 2' }, cmd: ['command'] });
   e(`a='1 2' b='3 4' command`, { env: { a: '1 2', b: '3 4' }, cmd: ['command'] });
   e(`NODE_OPTIONS='-r next-logger' command`, { env: { NODE_OPTIONS: '-r next-logger' }, cmd: ['command'] });
+  // NODE_OPTIONS example in https://nodejs.org/dist/latest-v16.x/docs/api/cli.html#node_optionsoptions
+  e(`NODE_OPTIONS='--inspect=localhost:4444' command`, { env: { NODE_OPTIONS: '--inspect=localhost:4444' }, cmd: ['command'] });
 });
 
 describe('bin', () => {


### PR DESCRIPTION
Some `NODE_OPTIONS` command-line options take a value, e.g. [`--inspect[=[host:]port]`](https://nodejs.org/dist/latest-v16.x/docs/api/cli.html#--inspecthostport), [`--max-http-header-size=size`](https://nodejs.org/dist/latest-v16.x/docs/api/cli.html#--max-http-header-sizesize). Currently anything past the first `=` in what would be the environment variable value is truncated. This Pull Request fixes this by splitting only by the first `=` discovered.

